### PR TITLE
Removed the SubscriberCounter from DOMWatcher

### DIFF
--- a/DomUpdates_1/DomUpdates_1.cs
+++ b/DomUpdates_1/DomUpdates_1.cs
@@ -73,9 +73,9 @@ public class DOMIncidentDataSource : IGQIDataSource, IGQIOnInit, IGQIUpdateable
     public void OnStopUpdates()
     {
         // Log("Stop updates.");
-        // No need to dispose the watcher as the underlying connection and its subscriptions are cleaned up automatically by GQI
-        // whenever the end of the life cycle of this data source is reached.
-    }
+        _watcher.OnChanged -= Watcher_OnChanged;
+        _watcher.Dispose();
+	}
 
     internal GQIRow CreateRow(DomInstance instance)
     {


### PR DESCRIPTION
Removed the counter and instead use a null check on the private event. Which will only be null when no event handlers are attached.
Also re-added the cleanup of the subscriptions in the OnStopUpdates. The reasoning being that it feels strange not removing the handler in the OnStopUpdates for the unusual case that there could be an update from the DOMWatcher in between the OnStopUpdates and OnDestroy and then the handler would still fire right?